### PR TITLE
Hyperv compute

### DIFF
--- a/devstack_vm/bin/run_tests.sh
+++ b/devstack_vm/bin/run_tests.sh
@@ -13,7 +13,7 @@ mkdir -p "$TEMPEST_DIR"
 
 # Checkout stable commit for tempest to avoid possible
 # incompatibilities for plugin stored in Manila repo.
-TEMPEST_COMMIT="489f5e62"  # 15 June, 2015
+TEMPEST_COMMIT="3b1bb9be3265f"  # 28 Aug, 2015
 git checkout $TEMPEST_COMMIT
 
 # Install Manila Tempest integration

--- a/devstack_vm/bin/run_tests.sh
+++ b/devstack_vm/bin/run_tests.sh
@@ -17,7 +17,7 @@ TEMPEST_COMMIT="3b1bb9be3265f"  # 28 Aug, 2015
 git checkout $TEMPEST_COMMIT
 
 # Install Manila Tempest integration
-cp -r /opt/stack/manila/contrib/tempest/tempest/* $TEMPEST_BASE/tempest
+cp -r /opt/stack/manila/manila_tempest_tests/* $TEMPEST_BASE/tempest
 
 cd /opt/stack/tempest
 testr list-tests | grep share | grep -Ev "tempest.api.image|tempest.scenario" > "$RUN_TESTS_LIST" || echo "failed to generate list of tests"


### PR DESCRIPTION
Manila tempest tests path changed and because of this tempest tests list generation failed.
Also updates to a newer stable tempest commit for manila tempest tests.