### PR TITLE
Set proper version of Tempest for Manila tests

### DIFF
--- a/devstack_vm/bin/run_tests.sh
+++ b/devstack_vm/bin/run_tests.sh
@@ -13,7 +13,7 @@ mkdir -p "$TEMPEST_DIR"
 
 # Checkout stable commit for tempest to avoid possible
 # incompatibilities for plugin stored in Manila repo.
-TEMPEST_COMMIT="3b1bb9be3265f"  # 28 Aug, 2015
+TEMPEST_COMMIT=${TEMPEST_COMMIT:-"c43c8f91"}  # 05 Nov, 2015
 git checkout $TEMPEST_COMMIT
 
 export OS_TEST_TIMEOUT=2400


### PR DESCRIPTION
Manila Tempest plugin was updated for work with latest Tempest and
it is no more compatible with old versions of Tempest.
So, update version of Tempest and allow to redefine it via env var
"TEMPEST_COMMIT" to be able to pull version from Manila project with
each such update in future.
