### PR TITLE
temp fix for Cinder failing to attach second volume to instance

### DIFF
--- a/devstack_vm/bin/update_devstack_repos.sh
+++ b/devstack_vm/bin/update_devstack_repos.sh
@@ -69,3 +69,9 @@ do
 done
 
 popd
+
+pushd $BASEDIR/cinder
+#temporary fix for multiple volumes to one instance bug
+#https://bugs.launchpad.net/tempest/+bug/1633535
+git revert --no-edit 6f174b412696bfa6262a5bea3ac42f45efbbe2ce
+popd


### PR DESCRIPTION
fixes bug https://bugs.launchpad.net/tempest/+bug/1633535 by reverting
the problematic commit until it's fixed upstream
