### PR TITLE
Moved tempest iniset to run_tests

### DIFF
--- a/devstack_vm/bin/run_tests.sh
+++ b/devstack_vm/bin/run_tests.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
 
+source /home/ubuntu/devstack/functions
+TEMPEST_CONFIG=/opt/stack/tempest/etc/tempest.conf
+
+echo "Updating tempest settings"
+iniset $TEMPEST_CONFIG identity username demo
+iniset $TEMPEST_CONFIG identity password Passw0rd
+iniset $TEMPEST_CONFIG identity tenant_name demo
+iniset $TEMPEST_CONFIG identity alt_username alt_demo
+iniset $TEMPEST_CONFIG identity alt_password Passw0rd
+iniset $TEMPEST_CONFIG identity admin_username admin
+iniset $TEMPEST_CONFIG identity admin_password Passw0rd
+iniset $TEMPEST_CONFIG identity admin_tenant_name admin
+
+iniset $TEMPEST_CONFIG share enable_protocols cifs
+iniset $TEMPEST_CONFIG share enable_ip_rules_for_protocols ""
+iniset $TEMPEST_CONFIG share enable_user_rules_for_protocols cifs
+iniset $TEMPEST_CONFIG share enable_ro_access_level_for_protocols cifs
+iniset $TEMPEST_CONFIG share storage_protocol CIFS
+iniset $TEMPEST_CONFIG share image_with_share_tools ws2012r2
+iniset $TEMPEST_CONFIG share image_username Admin
+iniset $TEMPEST_CONFIG share client_vm_flavor_ref 100
+iniset $TEMPEST_CONFIG share build_timeout 2400
+
+public_id=`neutron net-list | grep public | awk '{print $2}'`
+iniset $TEMPEST_CONFIG network public_network_id $public_id
+
 TEMPEST_BASE="/opt/stack/tempest"
 
 cd $TEMPEST_BASE

--- a/devstack_vm/devstack/local.sh
+++ b/devstack_vm/devstack/local.sh
@@ -14,34 +14,6 @@ echo "Add DNS config to the private network"
 subnet_id=`neutron net-show private | grep subnets | awk '{print $4}'`
 neutron subnet-update $subnet_id --dns_nameservers list=true 8.8.8.8 8.8.4.4
 
-TEMPEST_CONFIG=/opt/stack/tempest/etc/tempest.conf
-
-echo "Updating tempest settings"
-iniset $TEMPEST_CONFIG identity username demo
-iniset $TEMPEST_CONFIG identity password Passw0rd
-iniset $TEMPEST_CONFIG identity tenant_name demo
-iniset $TEMPEST_CONFIG identity alt_username alt_demo
-iniset $TEMPEST_CONFIG identity alt_password Passw0rd
-iniset $TEMPEST_CONFIG identity admin_username admin
-iniset $TEMPEST_CONFIG identity admin_password Passw0rd
-iniset $TEMPEST_CONFIG identity admin_tenant_name admin
-
-iniset $TEMPEST_CONFIG share enable_protocols cifs
-iniset $TEMPEST_CONFIG share enable_ip_rules_for_protocols ""
-iniset $TEMPEST_CONFIG share enable_user_rules_for_protocols cifs
-iniset $TEMPEST_CONFIG share enable_ro_access_level_for_protocols cifs
-iniset $TEMPEST_CONFIG share storage_protocol CIFS
-iniset $TEMPEST_CONFIG share image_with_share_tools ws2012r2
-iniset $TEMPEST_CONFIG share image_username Admin
-iniset $TEMPEST_CONFIG share client_vm_flavor_ref 100
-iniset $TEMPEST_CONFIG share build_timeout 2400
-
-public_id=`neutron net-list | grep public | awk '{print $2}'`
-iniset $TEMPEST_CONFIG network public_network_id $public_id
-
-# router_id=`neutron router-list | grep router | awk '{print $2}'
-# iniset $TEMPEST_CONFIG network public_router_id $router_id
-
 # Add a route for the private network
 router_ip=`neutron router-list | grep router1 | grep -oP '(?<=ip_address": ").*(?=")'`
 sudo ip route replace 172.20.1.0/24 via $router_ip


### PR DESCRIPTION
They were previously placed in local.sh, but it seems that stack.sh
overwrites them.